### PR TITLE
Fix: changed status and response when you verifying again

### DIFF
--- a/src/GraphQLSchemaBuilder.php
+++ b/src/GraphQLSchemaBuilder.php
@@ -3021,8 +3021,8 @@ class GraphQLSchemaBuilder
             if ($user->getVerified() == 1) {
                 $this->logger->info('Account is already verified', ['userid' => $userid]);
                 return [
-                    'status' => 'success',
-                    'ResponseCode' => 20701
+                    'status' => 'error',
+                    'ResponseCode' => 30701
                 ];
             }
 


### PR DESCRIPTION
here is the response:
{
    "data": {
        "verifyAccount": {
            "status": "error",
            "ResponseCode": "30701"
        }
    }
}