### PR TITLE
Fix PeerInputFilter tag responsecode by limiting of tagname

### DIFF
--- a/src/Filter/PeerInputFilter.php
+++ b/src/Filter/PeerInputFilter.php
@@ -660,7 +660,7 @@ class PeerInputFilter
         $value = htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
 
         if (strlen($value) < 2 || strlen($value) > 53) {
-            $this->errors['tag'][] = 30103;
+            $this->errors['tag'][] = 30211;
             return false;
         }
 


### PR DESCRIPTION
Fix PeerInputFilter tag responsecode by limiting of tagname length.