### PR TITLE
feat(base64handler): allow audio/x-wav

### DIFF
--- a/src/Services/Base64FileHandler.php
+++ b/src/Services/Base64FileHandler.php
@@ -25,7 +25,7 @@ class Base64FileHandler
                 'video/x-msvideo', 'video/3gpp', 'video/x-matroska',
                 'video/webm'
             ],
-            'audio' => ['audio/mpeg', 'audio/wav',"audio/ogg", "audio/x-wav"],
+            'audio' => ['audio/mpeg', 'audio/wav','audio/ogg', 'audio/x-wav', 'audio/webm'],
             'text' => ['text/plain'],
             default => []
         };


### PR DESCRIPTION
Extended supported MIME types in the Base64FileHandler service.

🛠 Changes
Added support for audio/x-wav MIME type to the audio group in Base64FileHandler.

🔍 Context
This change ensures that audio files with the audio/x-wav MIME type are correctly recognized and processed by the Base64FileHandler. This format is commonly used and may be required for compatibility with certain clients or file uploads.