### PR TITLE
changed db host port ,to stop conflict with global postgres default h…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - ./sql_files_for_import:/docker-entrypoint-initdb.d
       - peer_backend_ci-cd_db-data:/var/lib/postgresql/data
     ports:
-      - "5432:5432"
+      - "55432:5432"
     networks:
       - my-network
     healthcheck:


### PR DESCRIPTION
global postgres port runs outside host on 5432 and this conflicts with devs Postgres port on docker . so changing the port outside docker to 55432 fix this problem so devs doesn’t encount postgress port issues anymore